### PR TITLE
Pre-cook use cases vignette

### DIFF
--- a/vignettes/use-cases.Rmd
+++ b/vignettes/use-cases.Rmd
@@ -35,7 +35,7 @@ To demonstrate this use case we use the `hellow` R package source code that ship
 
 We will first move the example `hellow` package to temporary location:
 
-```{r}
+```{r, eval=FALSE}
 library(pracpac)
 library(fs)
 
@@ -49,25 +49,73 @@ dir_copy(path = system.file("hellow", package = "pracpac"), new_path = path(tmp,
 
 The new directory includes the R package source contents of `hellow`:
 
-```{r}
+<!-- NOTE: eval=FALSE to use precooked results in the verbatim chunk that follows -->
+<!-- NOTE: We will need to re-run and update this with future changes in the code -->
+
+```{r, eval=FALSE}
 dir_tree(path(tmp, "example", "hellow"), recurse = TRUE)
+```
+
+```
+├── DESCRIPTION
+├── NAMESPACE
+├── R
+│   └── hello.R
+└── man
+    └── isay.Rd
 ```
 
 We can use `use_docker(..., use_case="pipeline")` to create the template of files for building the Docker image:
 
-```{r, results='hide'}
+<!-- NOTE: eval=FALSE to use precooked results in the verbatim chunk that follows -->
+<!-- NOTE: We will need to re-run and update this with future changes in the code -->
+
+```{r, results='hide', eval=FALSE}
 use_docker(pkg_path = path(tmp, "example", "hellow"), use_case = "pipeline")
+```
+
+```
+Using renv. Dockerfile will build from renv.lock in /tmp/RtmpsMexB6/example/hellow/docker.
+Using template for the specified use case: pipeline
+Writing dockerfile: /tmp/RtmpsMexB6/example/hellow/docker/Dockerfile
+The directory will be created at /tmp/RtmpsMexB6/example/hellow/docker/assets 
+Assets for the specified use case (pipeline) will be copied there.
+The specified use case (pipeline) includes the following asset: run.sh
+The specified use case (pipeline) includes the following asset: pre.R
+The specified use case (pipeline) includes the following asset: post.R
+Building package hellow version 0.1.0 in /tmp/RtmpsMexB6/example/hellow/hellow_0.1.0.tar.gz
 ```
 
 The directory now contains the `docker/` subdirectory, which has another subdirectory called `assets/` for the templated pipeline scripts:
 
-```{r}
+<!-- NOTE: eval=FALSE to use precooked results in the verbatim chunk that follows -->
+<!-- NOTE: We will need to re-run and update this with future changes in the code -->
+
+```{r, eval=FALSE}
 dir_tree(path(tmp, "example", "hellow"), recurse = TRUE)
+```
+
+```
+├── DESCRIPTION
+├── NAMESPACE
+├── R
+│   └── hello.R
+├── docker
+│   ├── Dockerfile
+│   ├── assets
+│   │   ├── post.R
+│   │   ├── pre.R
+│   │   └── run.sh
+│   ├── hellow_0.1.0.tar.gz
+│   └── renv.lock
+└── man
+    └── isay.Rd
 ```
 
 The files need to be edited as follows:
 
 #### `Dockerfile`
+
 ```{bash eval=FALSE, echo=TRUE, code=readLines(system.file("example", "hellow", "Dockerfile", package = "pracpac"))}
 ```
 
@@ -83,9 +131,8 @@ The files need to be edited as follows:
 
 Note that in this case the `docker/assets/post.R` template is not necessary, so we can delete it:
 
-```{r}
+```{r, eval=FALSE}
 file_delete(path(tmp, "example", "hellow", "docker", "assets", "post.R"))
-
 ```
 
 ### Building the image
@@ -97,7 +144,6 @@ build_image(pkg_path = path(tmp, "example", "hellow"))
 ```
 
 In this case, the image will be built with `build_image()` default behavior of tagging with the package name and version:
-
 
 ```{r, eval=FALSE}
 system("docker images | grep 'hellow'")
@@ -146,7 +192,7 @@ Translations of [1] "What's up?"
     [1] "¿Qué pasa?", [1] "¿Qué hay de nuevo?"
 ```
 
-```{r, echo=FALSE}
+```{r, echo=FALSE, eval=FALSE}
 ## cleanup needed in case on vignette rebuild the same tmp directory is picked
 dir_delete(path = path(tmp, "example"))
 ```


### PR DESCRIPTION
note destination branch is `pipeline-vignette`.

One commit here that precooks the vignette output. Code is not evaluated, and output I get running interactively is hard-coded into the Rmd rather than knitted in. Notes throughout that if code changes, we'll need to update the output and messages.

Thinking ahead, the vignette takes time to build when eval=TRUE, and we're issuing system commands, tempdirs, etc., both of which I imagine may cause issues with a CRAN submission. 