### PR TITLE
Fix for no imports

### DIFF
--- a/R/docker.R
+++ b/R/docker.R
@@ -108,7 +108,11 @@ add_dockerfile <- function(pkg_path = ".", img_path = NULL, use_renv = TRUE, use
   info <- pkg_info(pkg_path)
 
   # Turn the string vector: c("a", "b", "c") to the single element string "'a','b','c'"
-  pkgs <- paste(paste0("'",info$pkgdeps,"'"), collapse=",")
+  if (length(info$pkgdeps==0L)) {
+    pkgs <- paste(paste0("'",info$pkgdeps,"'"), collapse=",")
+  } else {
+    pkgs <- character(0)
+  }
 
   ## if the image path is not given then construct path as subdirectory of pkg
   ## otherwise use the specified image path

--- a/R/docker.R
+++ b/R/docker.R
@@ -107,7 +107,9 @@ add_dockerfile <- function(pkg_path = ".", img_path = NULL, use_renv = TRUE, use
   # Check that path is a package
   info <- pkg_info(pkg_path)
 
-  # Turn the string vector: c("a", "b", "c") to the single element string "'a','b','c'"
+  # Turn the string vector: c("a", "b", "c") to the single element string "'a','b','c'".
+  # If info$pkgdeps is empty, create a string 'character(0)' that gets glued into the dockerfile template.
+  # Note this must be a quoted string 'character(0)', not an empty string character(0), for the glue to work properly.
   if (length(info$pkgdeps==0L)) {
     pkgs <- paste(paste0("'",info$pkgdeps,"'"), collapse=",")
   } else {

--- a/R/docker.R
+++ b/R/docker.R
@@ -111,7 +111,7 @@ add_dockerfile <- function(pkg_path = ".", img_path = NULL, use_renv = TRUE, use
   if (length(info$pkgdeps==0L)) {
     pkgs <- paste(paste0("'",info$pkgdeps,"'"), collapse=",")
   } else {
-    pkgs <- character(0)
+    pkgs <- 'character(0)'
   }
 
   ## if the image path is not given then construct path as subdirectory of pkg

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,8 +27,12 @@ pkg_info <- function(pkg_path=".", ...) {
   descfile <- fs::path(pkg_root, "DESCRIPTION")
 
   # Get package dependencies
-  pkgdeps <- strsplit(as.data.frame(read.dcf(descfile),stringsAsFactors=FALSE)$Imports, split=",\\n")[[1]]
-
+  imports <- as.data.frame(read.dcf(descfile),stringsAsFactors=FALSE)$Imports
+  if (is.null(imports)) {
+    pkgdeps <- character(0)
+  } else {
+    pkgdeps <- strsplit(imports, split=",\\n")[[1]]
+  }
   # Get the name and version from it
   pkgname <- strsplit(grep("^Package:", readLines(descfile), value=TRUE), split=" ")[[1]][2]
   pkgver <- strsplit(grep("^Version:", readLines(descfile), value=TRUE), split=" ")[[1]][2]

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,7 +26,11 @@ pkg_info <- function(pkg_path=".", ...) {
   # Find the description file
   descfile <- fs::path(pkg_root, "DESCRIPTION")
 
-  # Get package dependencies
+  # Get package dependencies.
+  # If there are no dependencies, make pkgdeps an empty string, character(0).
+  # Both of these are perfectly valid, and result in nothing actually being installed:
+  # BiocManager::install(c(character(0)), update=FALSE, ask=FALSE)
+  # install.packages(c(character(0)))
   imports <- as.data.frame(read.dcf(descfile),stringsAsFactors=FALSE)$Imports
   if (is.null(imports)) {
     pkgdeps <- character(0)


### PR DESCRIPTION
## Summary

Very simple fix for #91 

You can't use NULL, NA, or `''` to `install.packages()` or `BiocManager::install()`; but an empty character vector is okay:

```
> BiocManager::install(c(character(0)), update=FALSE, ask=FALSE)
'getOption("repos")' replaces Bioconductor standard repositories, see '?repositories' for details

replacement repositories:
    CRAN: https://cloud.r-project.org/

Bioconductor version 3.15 (BiocManager 1.30.18), R 4.2.0 (2022-04-22)
> install.packages(c(character(0)))
> 
```

This PR sets `info$pkgdeps` to `character(0)` and the `pkgs` string to `'character(0)'`. All tests pass, `devtools::check()` OK, images build cleanly for all examples below. 

Fixes #91 

## Examples

Here's a package with no imports (or DIY with RStudio new project -> package): 
[nodep.zip](https://github.com/signaturescience/pracpac/files/10940810/nodep.zip)

### Defaults: `use_docker(use_renv = TRUE, other_packages = NULL)`

Dockerfile has no relevant changes with `use_renv=TRUE`

```dockerfile
FROM rocker/r-ver:latest

## copy the renv.lock into the image
COPY renv.lock /renv.lock

## install renv and biocmanager
RUN Rscript -e 'install.packages(c("renv","BiocManager"), repos="https://cloud.r-project.org")'

## set the renv path var to the renv lib
ENV RENV_PATHS_LIBRARY renv/library

## restore packages from renv.lock
RUN Rscript -e 'renv::restore(lockfile = "/renv.lock", repos = NULL)'

## copy in built R package
COPY nodep_0.1.0.tar.gz /nodep_0.1.0.tar.gz

## run script to install built R package from source
RUN Rscript -e "install.packages('/nodep_0.1.0.tar.gz', type='source', repos=NULL)"
```

renv.lock is empty, but this is completely fine with `renv::restore()`.

```json
{
  "R": {
    "Version": "4.2.0",
    "Repositories": [
      {
        "Name": "CRAN",
        "URL": "https://cloud.r-project.org"
      }
    ]
  },
  "Packages": {}
}
```

### With other pkgs: `use_docker(use_renv = TRUE, other_packages = c("R6", "pkgbuild"))`

`renv.lock` contains R6, pkgbuild, and pkgbuild deps

<details><summary>Click to expand renv.lock...</summary>

```json
{
  "R": {
    "Version": "4.2.0",
    "Repositories": [
      {
        "Name": "CRAN",
        "URL": "https://cloud.r-project.org"
      }
    ]
  },
  "Packages": {
    "R6": {
      "Package": "R6",
      "Version": "2.5.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "470851b6d5d0ac559e9d01bb352b4021",
      "Requirements": []
    },
    "callr": {
      "Package": "callr",
      "Version": "3.7.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "2fda237f24bc56508f31394beaa56877",
      "Requirements": [
        "R6",
        "processx"
      ]
    },
    "cli": {
      "Package": "cli",
      "Version": "3.6.0",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "3177a5a16c243adc199ba33117bd9657",
      "Requirements": []
    },
    "crayon": {
      "Package": "crayon",
      "Version": "1.5.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "8dc45fd8a1ee067a92b85ef274e66d6a",
      "Requirements": []
    },
    "desc": {
      "Package": "desc",
      "Version": "1.4.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "eebd27ee58fcc58714eedb7aa07d8ad1",
      "Requirements": [
        "R6",
        "cli",
        "rprojroot"
      ]
    },
    "pkgbuild": {
      "Package": "pkgbuild",
      "Version": "1.3.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "66d2adfed274daf81ccfe77d974c3b9b",
      "Requirements": [
        "R6",
        "callr",
        "cli",
        "crayon",
        "desc",
        "prettyunits",
        "rprojroot",
        "withr"
      ]
    },
    "prettyunits": {
      "Package": "prettyunits",
      "Version": "1.1.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "95ef9167b75dde9d2ccc3c7528393e7e",
      "Requirements": []
    },
    "processx": {
      "Package": "processx",
      "Version": "3.7.0",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "f91df0f5f31ffdf88bc0b624f5ebab0f",
      "Requirements": [
        "R6",
        "ps"
      ]
    },
    "ps": {
      "Package": "ps",
      "Version": "1.7.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "8b93531308c01ad0e56d9eadcc0c4fcd",
      "Requirements": []
    },
    "rprojroot": {
      "Package": "rprojroot",
      "Version": "2.0.3",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "1de7ab598047a87bba48434ba35d497d",
      "Requirements": []
    },
    "withr": {
      "Package": "withr",
      "Version": "2.5.0",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "c0e49a9760983e81e55cdd9be92e7182",
      "Requirements": []
    }
  }
}
```

</details>

### Not using renv: `add_dockerfile(use_renv=FALSE)`

Dockerfile:

```dockerfile
FROM rocker/r-ver:latest

COPY nodep_0.1.0.tar.gz /nodep_0.1.0.tar.gz

# Domain-specific stuff here
# RUN apt update && apt install -y yourpackages

RUN Rscript -e 'install.packages("BiocManager")'
RUN Rscript -e "BiocManager::install(c(character(0)), update=FALSE, ask=FALSE)"
RUN Rscript -e "install.packages('/nodep_0.1.0.tar.gz', type='source', repos=NULL)"
```